### PR TITLE
Add syntax highlighting for autoconf variables

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -361,7 +361,7 @@
         'name': 'variable.language.makefile'
       }
       {
-        'match': '@\\w+@'
+        'match': '\\b@\\w+@\\b'
         'name': 'string.interpolated.makefile'
       }
       {


### PR DESCRIPTION
Add syntax highlighting for autoconf variable substitution (@VARIABLE@)
![screenshot](https://cloud.githubusercontent.com/assets/3471434/3999500/c6593816-2950-11e4-8017-202fdf7dd147.png)
