### PR TITLE
Allow tabs in recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: objective-c
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Make language support in Atom
+# Make language support in Atom [![Build Status](https://travis-ci.org/atom/language-make.svg?branch=master)](https://travis-ci.org/atom/language-make)
 
 Adds syntax highlighting to [Makefiles](http://www.gnu.org/software/make/manual/make.html)
 in Atom.

--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -253,7 +253,7 @@
       }
     ]
   'recipe':
-    'begin': '^([^:]*)(:)(?!\\=)'
+    'begin': '^(?!\\t)([^:]*)(:)(?!\\=)'
     'beginCaptures':
       '1':
         'patterns': [
@@ -303,30 +303,6 @@
             'include': '#variables'
           }
         ]
-      }
-      {
-        'begin': '^\\t'
-        'name': 'meta.scope.recipe.makefile'
-        'patterns': [
-          {
-            'captures':
-              '0':
-                'patterns': [
-                  {
-                    'match': '\\\\\\n'
-                    'name': 'constant.character.escape.continuation.makefile'
-                  }
-                  {
-                    'include': '#variables'
-                  }
-                  {
-                    'include': 'source.shell'
-                  }
-                ]
-            'match': '.+\\n?'
-          }
-        ]
-        'while': '^\\t'
       }
     ]
   'variable-assignment':

--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -253,7 +253,7 @@
       }
     ]
   'recipe':
-    'begin': '^(?!\\t)([^:]*)(:)(?!\\=)'
+    'begin': '^([^:]*)(:)(?!\\=)'
     'beginCaptures':
       '1':
         'patterns': [

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -1,0 +1,19 @@
+describe "Makefile grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-make")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.makefile")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe "source.makefile"
+
+  it "parses recipes", ->
+    lines = grammar.tokenizeLines 'all: foo.bar\n\ttest\n\nclean: foo\n\trm -fr foo.bar'
+
+    expect(lines[0][0]).toEqual value: 'all', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
+    expect(lines[3][0]).toEqual value: 'clean', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']


### PR DESCRIPTION
Now, I'm not familiar with Make at all, having never used it.  So I did some research and it looks like only tabs are allowed (at least in most variations).  I'm not really sure why the recipe regex has a negative lookahead looking specifically for tabs, but that seems to go against Make's grammar rules, so I removed it.

Fixes #10