### PR TITLE
Add back recipe patterns

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -304,6 +304,23 @@
           }
         ]
       }
+      {
+        'begin': '^\\t'
+        'end': '$'
+        'name': 'meta.scope.recipe.makefile'
+        'patterns': [
+          {
+            'match': '\\\\\\n'
+            'name': 'constant.character.escape.continuation.makefile'
+          }
+          {
+            'include': '#variables'
+          }
+          {
+            'include': 'source.shell'
+          }
+        ]
+      }
     ]
   'variable-assignment':
     'begin': '(^[ ]*|\\G\\s*)([^\\s]+)\\s*(=|\\?=|:=|\\+=)'

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -23,6 +23,6 @@ describe "Makefile grammar", ->
     expect(tokens[4]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.prerequisites.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']
 
   it "parses targets with line breaks in body", ->
-    lines = grammar.tokenizeLines "foo:\n\techo $(basename /foo/bar.txt)"
+    lines = grammar.tokenizeLines 'foo:\n\techo $(basename /foo/bar.txt)'
 
     expect(lines[1][3]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -17,3 +17,12 @@ describe "Makefile grammar", ->
 
     expect(lines[0][0]).toEqual value: 'all', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
     expect(lines[3][0]).toEqual value: 'clean', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
+
+  it "parses function calls", ->
+    {tokens} = grammar.tokenizeLine 'foo: echo $(basename /foo/bar.txt)'
+    expect(tokens[4]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.prerequisites.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']
+
+  it "parses targets with line breaks in body", ->
+    lines = grammar.tokenizeLines "foo:\n\techo $(basename /foo/bar.txt)"
+
+    expect(lines[1][3]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']


### PR DESCRIPTION
This adds back the previously broken `while` pattern and refactors it to be a `begin`/`end` pattern.

Refs #10 
Fixes #18 