### PR TITLE
Generate grammar using GNU Make Manual as input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+make.html

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ from the [Make TextMate bundle](https://github.com/textmate/make.tmbundle).
 Contributions are greatly appreciated. Please fork this repository and open a
 pull request to add snippets, make grammar tweaks, etc.
 
-# Development
+## Development
 
 Grammar is generated from files in `src/`.  Lists of language variables and functions are
 generated from parsing [GNU Make Manual](http://www.gnu.org/software/make/manual/make.html).
-For re-generating `makefile.cson`, simply run package tests.  Or run
+For re-generating `makefile.cson`, simply run package tests or run
 ```
     $ coffee src/makefile.coffee
 ```
 
-If it happens, that you get a timeout in the first place, this is most likely, that
-fetching gnu make manual took a while.
+If it happens while running package tests, that you get a timeout in the first
+place, this is most likely, that fetching gnu make manual took a while.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ from the [Make TextMate bundle](https://github.com/textmate/make.tmbundle).
 
 Contributions are greatly appreciated. Please fork this repository and open a
 pull request to add snippets, make grammar tweaks, etc.
+
+# Development
+
+Grammar is generated from files in `src/`.  Lists of language variables and functions are
+generated from parsing [GNU Make Manual](http://www.gnu.org/software/make/manual/make.html).
+For re-generating `makefile.cson`, simply run package tests.  Or run
+```
+    $ coffee src/makefile.coffee
+```
+
+If it happens, that you get a timeout in the first place, this is most likely, that
+fetching gnu make manual took a while.

--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -1,5 +1,3 @@
-'scopeName': 'source.makefile'
-'name': 'Makefile'
 'fileTypes': [
   'Makefile'
   'makefile'
@@ -10,12 +8,14 @@
   'Makefile.in'
 ]
 'firstLineMatch': '^#!\\s*/.*\\bmake\\s+-f'
+'name': 'Makefile'
+'scopeName': 'source.makefile'
 'patterns': [
   {
     'include': '#comment'
   }
   {
-    'include': '#variable-assignment'
+    'include': '#variableAssignment'
   }
   {
     'include': '#recipe'
@@ -26,23 +26,27 @@
 ]
 'repository':
   'comment':
-    'begin': '(^[ \\t]+)?(?=#)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.makefile'
-    'end': '(?!\\G)'
     'patterns': [
       {
-        'begin': '#'
+        'begin': '(^[ \\t]+)?(?=#)'
         'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.makefile'
-        'end': '\\n'
-        'name': 'comment.line.number-sign.makefile'
+          '1':
+            'name': 'punctuation.whitespace.comment.leading.makefile'
+        'end': '(?!\\G)'
         'patterns': [
           {
-            'match': '\\\\\\n'
-            'name': 'constant.character.escape.continuation.makefile'
+            'begin': '#'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.makefile'
+            'end': '\\n'
+            'name': 'comment.line.number-sign.makefile'
+            'patterns': [
+              {
+                'match': '\\\\\\n'
+                'name': 'constant.character.escape.continuation.makefile'
+              }
+            ]
           }
         ]
       }
@@ -89,7 +93,7 @@
       }
       {
         'begin': '^(?:(override)\\s*)?(define)\\s*([^\\s]+)\\s*(=|\\?=|:=|\\+=)?(?=\\s)'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'keyword.control.override.makefile'
           '2':
@@ -129,7 +133,7 @@
             'include': '#comment'
           }
           {
-            'include': '#variable-assignment'
+            'include': '#variableAssignment'
           }
           {
             'match': '[^\\s]+'
@@ -145,10 +149,7 @@
         'end': '^'
         'patterns': [
           {
-            'include': '#comment'
-          }
-          {
-            'include': '#variable-assignment'
+            'include': '#variableAssignment'
           }
         ]
       }
@@ -170,7 +171,7 @@
       }
       {
         'begin': '^(ifdef|ifndef)\\s*([^\\s]+)(?=\\s)'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'keyword.control.$1.makefile'
           '2':
@@ -196,7 +197,7 @@
       }
       {
         'begin': '^(ifeq|ifneq)(?=\\s)'
-        'captures':
+        'beginCaptures':
           '1':
             'name': 'keyword.control.$1.makefile'
         'end': '^(endif)\\b'
@@ -229,73 +230,124 @@
       }
     ]
   'interpolation':
-    'begin': '(?=`)'
-    'end': '(?!\\G)'
-    'name': 'meta.embedded.line.shell'
     'patterns': [
       {
-        'begin': '`'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.makefile'
-        'contentName': 'source.shell'
-        'end': '(`)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.makefile'
-          '1':
-            'name': 'source.shell'
-        'name': 'string.interpolated.backtick.makefile'
+        'begin': '(?=`)'
+        'end': '(?!\\G)'
+        'name': 'meta.embedded.line.shell.makefile'
         'patterns': [
           {
-            'include': 'source.shell'
+            'begin': '`'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.string.makefile'
+            'contentName': 'source.shell.makefile'
+            'end': '(`)'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.string.makefile'
+              '1':
+                'name': 'source.shell.makefile'
+            'name': 'string.interpolated.backtick.makefile'
+            'patterns': [
+              {
+                'include': 'source.shell'
+              }
+            ]
           }
         ]
       }
     ]
   'recipe':
-    'begin': '^(?!\\t)([^:]*)(:)(?!\\=)'
-    'beginCaptures':
-      '1':
+    'patterns': [
+      {
+        'begin': '^(?!\\t)([^:]*)(:)(?!\\=)'
+        'beginCaptures':
+          '1':
+            'patterns': [
+              {
+                'match': '^\\s*(\\\\.)((?:DE(?:FAULT|LETE_ON_ERROR)|EXPORT_ALL_VARIABLES|I(?:GNORE|NTERMEDIATE)|L(?:IBPATTERNS|O(?:ADED|W_RESOLUTION_TIME))|NOTPARALLEL|ONESHELL|P(?:HONY|OSIX|RECIOUS)|S(?:ECOND(?:ARY|EXPANSION)|HELLFLAGS|ILENT|UFFIXES)))\\s*$'
+                'captures':
+                  '1':
+                    'name': 'punctuation.definition.target.special.makefile'
+                  '2':
+                    'name': 'support.function.target.$1.makefile'
+              }
+              {
+                'begin': '(?=\\S)'
+                'end': '(?=\\s|$)'
+                'name': 'entity.name.function.target.makefile'
+                'patterns': [
+                  {
+                    'include': '#variables'
+                  }
+                  {
+                    'match': '%'
+                    'name': 'constant.other.placeholder.makefile'
+                  }
+                ]
+              }
+            ]
+          '2':
+            'name': 'punctuation.separator.key-value.makefile'
+        'end': '^(?!\\t)'
+        'name': 'meta.scope.target.makefile'
         'patterns': [
           {
-            'captures':
-              '1':
-                'name': 'support.function.target.$1.makefile'
-            'match': '^\\s*(\\.(PHONY|SUFFIXES|DEFAULT|PRECIOUS|INTERMEDIATE|SECONDARY|SECONDEXPANSION|DELETE_ON_ERROR|IGNORE|LOW_RESOLUTION_TIME|SILENT|EXPORT_ALL_VARIABLES|NOTPARALLEL|ONESHELL|POSIX))\\s*$'
+            'begin': '\\G'
+            'end': '^'
+            'name': 'meta.scope.prerequisites.makefile'
+            'patterns': [
+              {
+                'match': '\\\\\\n'
+                'name': 'constant.character.escape.continuation.makefile'
+              }
+              {
+                'match': '%|\\*'
+                'name': 'constant.other.placeholder.makefile'
+              }
+              {
+                'include': '#comment'
+              }
+              {
+                'include': '#variables'
+              }
+            ]
           }
           {
-            'begin': '(?=\\S)'
-            'end': '(?=\\s|$)'
-            'name': 'entity.name.function.target.makefile'
+            'begin': '^\\t'
+            'end': '$'
+            'name': 'meta.scope.recipe.makefile'
             'patterns': [
+              {
+                'match': '\\\\\\n'
+                'name': 'constant.character.escape.continuation.makefile'
+              }
               {
                 'include': '#variables'
               }
               {
-                'match': '%'
-                'name': 'constant.other.placeholder.makefile'
+                'include': 'source.shell'
               }
             ]
           }
         ]
-      '2':
-        'name': 'punctuation.separator.key-value.makefile'
-    'end': '^(?!\\t)'
-    'name': 'meta.scope.target.makefile'
+      }
+    ]
+  'variableAssignment':
     'patterns': [
       {
-        'begin': '\\G'
-        'end': '^'
-        'name': 'meta.scope.prerequisites.makefile'
+        'begin': '(^[ ]*|\\G\\s*)([^\\s]+)\\s*(=|\\?=|:=|\\+=)'
+        'beginCaptures':
+          '2':
+            'name': 'variable.other.makefile'
+          '3':
+            'name': 'punctuation.separator.key-value.makefile'
+        'end': '\\n'
         'patterns': [
           {
             'match': '\\\\\\n'
             'name': 'constant.character.escape.continuation.makefile'
-          }
-          {
-            'match': '%|\\*'
-            'name': 'constant.other.placeholder.makefile'
           }
           {
             'include': '#comment'
@@ -303,47 +355,10 @@
           {
             'include': '#variables'
           }
-        ]
-      }
-      {
-        'begin': '^\\t'
-        'end': '$'
-        'name': 'meta.scope.recipe.makefile'
-        'patterns': [
           {
-            'match': '\\\\\\n'
-            'name': 'constant.character.escape.continuation.makefile'
-          }
-          {
-            'include': '#variables'
-          }
-          {
-            'include': 'source.shell'
+            'include': '#interpolation'
           }
         ]
-      }
-    ]
-  'variable-assignment':
-    'begin': '(^[ ]*|\\G\\s*)([^\\s]+)\\s*(=|\\?=|:=|\\+=)'
-    'beginCaptures':
-      '2':
-        'name': 'variable.other.makefile'
-      '3':
-        'name': 'punctuation.separator.key-value.makefile'
-    'end': '\\n'
-    'patterns': [
-      {
-        'match': '\\\\\\n'
-        'name': 'constant.character.escape.continuation.makefile'
-      }
-      {
-        'include': '#comment'
-      }
-      {
-        'include': '#variables'
-      }
-      {
-        'include': '#interpolation'
       }
     ]
   'variables':
@@ -361,10 +376,13 @@
       }
       {
         'begin': '\\$?\\$\\('
-        'captures':
+        'beginCaptures':
           '0':
             'name': 'punctuation.definition.variable.makefile'
         'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.variable.makefile'
         'name': 'string.interpolated.makefile'
         'patterns': [
           {
@@ -374,11 +392,11 @@
             'include': '#variables'
           }
           {
-            'match': '\\G(MAKEFILES|VPATH|SHELL|MAKESHELL|MAKE|MAKELEVEL|MAKEFLAGS|MAKECMDGOALS|CURDIR|SUFFIXES|\\.LIBPATTERNS)(?=\\s*\\))'
+            'match': '\\G((?:%(?:D|F)|\\*(?:D|F)|\\+(?:D|F)|<(?:D|F)|\\?(?:D|F)|@(?:D|F)|A(?:R(?:FLAGS)?|S(?:FLAGS)?)|C(?:C|FLAGS|O(?:FLAGS)?|PP(?:FLAGS)?|TANGLE|WEAVE|XX(?:FLAGS)?)|F(?:C|FLAGS)|G(?:ET|FLAGS)|L(?:D(?:FLAGS|LIBS)|EX|FLAGS|INT(?:FLAGS)?|OADLIBES)|M(?:2C|AKE(?:FILES|INFO|LEVEL)?)|P(?:C|FLAGS)|R(?:FLAGS|M)|T(?:ANGLE|EX(?:I2DVI)?)|WEAVE|Y(?:ACC|FLAGS)|\\^(?:D|F)|bindir|ex(?:ec_prefix|port)|libexecdir|prefix|sbindir|unexport))(?=\\s*\\))'
             'name': 'variable.language.makefile'
           }
           {
-            'begin': '\\G(subst|patsubst|strip|findstring|filter(-out)?|sort|word(list)?|firstword|lastword|dir|notdir|suffix|basename|addprefix|join|wildcard|realpath|abspath|info|error|warning|shell|foreach|if|or|and|call|eval|value)\\s'
+            'begin': '\\G((?:a(?:bspath|dd(?:prefix|suffix)|nd)|basename|call|dir|e(?:rror|val)|f(?:i(?:l(?:e|ter(?:\\-out)?)|ndstring|rstword)|lavor|oreach)|guile|i(?:f|nfo)|join|lastword|notdir|or(?:igin)?|patsubst|realpath|s(?:hell|ort|trip|u(?:bst|ffix))|value|w(?:arning|ildcard|ord(?:list|s)?)))\\s'
             'beginCaptures':
               '1':
                 'name': 'support.function.$1.makefile'
@@ -400,7 +418,7 @@
           {
             'begin': '\\G(origin|flavor)\\s(?=[^\\s)]+\\s*\\))'
             'contentName': 'variable.other.makefile'
-            'end': '\\)'
+            'end': '(?=\\))'
             'name': 'meta.scope.function-call.makefile'
             'patterns': [
               {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"
+    "atom-syntax-tools": "^0.9.0",
+    "q": "^1.4.1"
+  },
+  "dependencies": {
   }
 }

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -1,7 +1,19 @@
+{createMakeGrammar} = require '../src/makefile.coffee'
+
+tokenizeLines = (grammar, args...) ->
+  lines = grammar.tokenizeLines args...
+
+  console.log "lines", lines
+  return lines
+
 describe "Makefile grammar", ->
   grammar = null
 
   beforeEach ->
+    waitsForPromise ->
+      debugger
+      createMakeGrammar()
+
     waitsForPromise ->
       atom.packages.activatePackage("language-make")
 
@@ -13,7 +25,7 @@ describe "Makefile grammar", ->
     expect(grammar.scopeName).toBe "source.makefile"
 
   it "parses recipes", ->
-    lines = grammar.tokenizeLines 'all: foo.bar\n\ttest\n\nclean: foo\n\trm -fr foo.bar'
+    lines = tokenizeLines grammar, 'all: foo.bar\n\ttest\n\nclean: foo\n\trm -fr foo.bar'
 
     expect(lines[0][0]).toEqual value: 'all', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
     expect(lines[3][0]).toEqual value: 'clean', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
@@ -23,7 +35,7 @@ describe "Makefile grammar", ->
     expect(tokens[4]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.prerequisites.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']
 
   it "parses targets with line breaks in body", ->
-    lines = grammar.tokenizeLines 'foo:\n\techo $(basename /foo/bar.txt)'
+    lines = tokenizeLines grammar, 'foo:\n\techo $(basename /foo/bar.txt)'
 
     expect(lines[1][3]).toEqual value: 'basename', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.basename.makefile']
 
@@ -32,7 +44,7 @@ describe "Makefile grammar", ->
       atom.packages.activatePackage("language-shellscript")
 
     runs ->
-      lines = grammar.tokenizeLines 'default:\n\t$(eval MESSAGE=$(shell node -pe "decodeURIComponent(process.argv.pop())" "${MSG}"))'
+      lines = tokenizeLines grammar, 'default:\n\t$(eval MESSAGE=$(shell node -pe "decodeURIComponent(process.argv.pop())" "${MSG}"))'
 
       expect(lines[1][1]).toEqual value: '$(', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'punctuation.definition.variable.makefile']
       expect(lines[1][2]).toEqual value: 'eval', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.eval.makefile']

--- a/src/makefile-grammar.coffee
+++ b/src/makefile-grammar.coffee
@@ -1,0 +1,314 @@
+###
+Generator for makefile.cson
+###
+
+{makeWords, makeRegexFromWords, rule} = require 'atom-syntax-tools'
+
+module.exports = (makeInfo) ->
+
+  console.log makeInfo
+
+  makeFuncs = makeRegexFromWords makeInfo.functions
+  makeVars  = makeRegexFromWords makeInfo.variables
+
+  console.log makeVars
+
+  makeTargets = makeRegexFromWords makeInfo.targets
+
+  placeholder =
+    m: /%/
+    n: 'constant.other.placeholder.makefile'
+
+  otherVariable =
+    m: /[^\s]+/
+    n: 'variable.other.makefile'
+
+  continuation =
+    m: /\\\n/
+    n: 'constant.character.escape.continuation.makefile'
+
+  grammar =
+    macros: {makeFuncs, makeTargets, makeVars}
+    scopeName: 'source.makefile'
+    name: 'Makefile'
+    fileTypes: [
+      'Makefile'
+      'makefile'
+      'GNUmakefile'
+      'OCamlMakefile'
+      'mf'
+      'mk'
+      'Makefile.in'
+    ]
+    firstLineMatch: /^#!\s*\/.*\bmake\s+-f/
+    patterns: [
+      '#comment'
+      '#variableAssignment'
+      '#recipe'
+      '#directives'
+    ]
+    repository:
+      comment:
+        b: /(^[ \t]+)?(?=#)/
+        c:
+          1: 'punctuation.whitespace.comment.leading.makefile'
+        e: /(?!\G)/
+        p: [
+          rule
+            b: /#/
+            c:
+              0: 'punctuation.definition.comment.makefile'
+            e: /\n/
+            n: 'comment.line.number-sign.makefile'
+            p: [
+              continuation
+            ]
+        ]
+      directives: [
+        rule
+          b: /^[ ]*([s\-]?include)\b/
+          c:
+            1: 'keyword.control.include.makefile'
+          e: /^/
+          p: [
+            '#comment'
+            '#variables'
+            placeholder
+          ]
+        rule
+          b: /^[ ]*(vpath)\b/
+          c:
+            1: 'keyword.control.vpath.makefile'
+          e: /^/
+          p: [
+            '#comment'
+            '#variables'
+            placeholder
+          ]
+        rule
+          b: /^(?:(override)\s*)?(define)\s*([^\s]+)\s*(=|\?=|:=|\+=)?(?=\s)/
+          c:
+            1: 'keyword.control.override.makefile'
+            2: 'keyword.control.define.makefile'
+            3: 'variable.other.makefile'
+            4: 'punctuation.separator.key-value.makefile'
+          e: /^(endef)\b/
+          n: 'meta.scope.conditional.makefile'
+          p: [
+            {
+              b: /\G(?!\n)/
+              e: /^/
+              p: [ '#comment' ]
+            }
+            '#variables'
+            '#comment'
+          ]
+        rule
+          b: /^[ ]*(export)\b/
+          c:
+            1: 'keyword.control.$1.makefile'
+          e: /^/
+          p: [
+            '#comment'
+            '#variableAssignment'
+            otherVariable
+          ]
+        rule
+          b: /^[ ]*(override|private)\b/
+          c:
+            1: 'keyword.control.$1.makefile'
+          e: /^/
+          p: [
+            'include': '#comment'
+            'include': '#variableAssignment'
+          ]
+        rule
+          b: /^[ ]*(unexport|undefine)\b/
+          c:
+            1: 'keyword.control.$1.makefile'
+          e: /^/
+          'patterns': [
+            '#comment'
+            otherVariable
+          ]
+        rule
+          b: /^(ifdef|ifndef)\s*([^\s]+)(?=\s)/
+          c:
+            1: 'keyword.control.$1.makefile'
+            2: 'variable.other.makefile'
+            3: 'punctuation.separator.key-value.makefile'
+          e: /^(endif)\b/
+          n: 'meta.scope.conditional.makefile'
+          p: [
+            rule
+              b: /\G(?!\n)/
+              e: /^/
+              p: [ '#comment' ]
+            '$self'
+          ]
+        rule
+            b: /^(ifeq|ifneq)(?=\s)/
+            c:
+              1: 'keyword.control.$1.makefile'
+            e: /^(endif)\b/
+            n: 'meta.scope.conditional.makefile'
+            p: [
+              rule
+                b: /\G/
+                e: /^/
+                n: 'meta.scope.condition.makefile'
+                p: [
+                  '#variables'
+                  '#comment'
+                ]
+
+              rule
+                b: /^else(?=\s)/
+                c:
+                  0: 'keyword.control.else.makefile'
+                e: /^/
+
+              '$self'
+            ]
+        ]
+
+      interpolation:
+        b: /(?=`)/
+        e: /(?!\G)/
+        n: 'meta.embedded.line.shell'
+        p: [
+          rule
+            begin: /`/
+            beginCaptures:
+              0: 'punctuation.definition.string.makefile'
+            contentName: 'source.shell'
+            end: /(`)/
+            endCaptures:
+              0: 'punctuation.definition.string.makefile'
+              1: 'source.shell'
+            name: 'string.interpolated.backtick.makefile'
+            patterns: [
+                'source.shell'
+            ]
+        ]
+      recipe:
+        b: /^(?!\t)([^:]*)(:)(?!\=)/
+        c:
+          1: [
+              rule
+                m: /^\s*(\\.)({makeTargets})\s*$/
+                c:
+                  1: 'punctuation.definition.target.special.makefile'
+                  2: 'support.function.target.$1.makefile'
+
+              rule
+                b: /(?=\S)/
+                e: /(?=\s|$)/
+                n: 'entity.name.function.target.makefile'
+                p: [
+                    '#variables'
+                    placeholder
+                ]
+            ]
+          2: 'punctuation.separator.key-value.makefile'
+        e: /^(?!\t)/
+        n: 'meta.scope.target.makefile'
+        p: [
+          rule
+            b: /\G/
+        #    e: /(?!\\\n)$/
+            e: /^/
+            n: 'meta.scope.prerequisites.makefile'
+            p: [
+              continuation
+
+              rule
+                m: /%|\*/
+                n: 'constant.other.placeholder.makefile'
+
+              '#comment'
+              '#variables'
+            ]
+          rule
+            begin: /^\t/
+            end: /$/
+            name: 'meta.scope.recipe.makefile'
+            patterns: [
+              continuation
+              '#variables'
+              'source.shell'
+            ]
+
+        ]
+      variableAssignment:
+        begin: /(^[ ]*|\G\s*)([^\s]+)\s*(=|\?=|:=|\+=)/
+        beginCaptures:
+          2: 'variable.other.makefile'
+          3: 'punctuation.separator.key-value.makefile'
+        end: /\n/
+        patterns: [
+          continuation
+          '#comment'
+          '#variables'
+          '#interpolation'
+        ]
+      variables:
+        patterns: [
+          rule
+            captures:
+              1: 'punctuation.definition.variable.makefile'
+            match: /(\$?\$)[@%<?^+*]/
+            name: 'variable.language.makefile'
+          rule
+            match: /\b@\w+@\b/
+            name: 'string.interpolated.makefile'
+          rule
+            b: /\$?\$\(/
+            c:
+              0: 'punctuation.definition.variable.makefile'
+            e: /\)/
+            C:
+              0: 'punctuation.definition.variable.makefile'
+            n: 'string.interpolated.makefile'
+            p: [
+              'source.shell#string'
+              '#variables'
+              rule
+                m: /\G({makeVars})(?=\s*\))/
+                n: 'variable.language.makefile'
+
+              rule
+                b: /\G({makeFuncs})\s/
+                c:
+                  1: 'support.function.$1.makefile'
+                e: /(?=\))/
+                n: 'meta.scope.function-call.makefile'
+                p: [
+                  '#variables'
+                  'source.shell#string'
+                  {
+                    m: /%|\*/
+                    n: 'constant.other.placeholder.makefile'
+                  }
+                ]
+              rule
+                begin: /\G(origin|flavor)\s(?=[^\s)]+\s*\))/
+                contentName: 'variable.other.makefile'
+                end: /(?=\))/
+                name: 'meta.scope.function-call.makefile'
+                patterns: [
+                  '#variables'
+                  'source.shell#string'
+                ]
+              rule
+                b: /\G(?!\))/
+                e: /(?=\))/
+                n: 'variable.other.makefile'
+                p: [
+                  '#variables'
+                  'source.shell#string'
+                ]
+            ]
+        ]
+
+  grammar

--- a/src/makefile.coffee
+++ b/src/makefile.coffee
@@ -1,0 +1,75 @@
+###
+$ coffee makefile.coffee
+###
+
+Q    = require 'q'
+path = require 'path'
+fs   = require 'fs'
+{makeGrammar} = require 'atom-syntax-tools'
+
+grammarFactory = require './makefile-grammar.coffee'
+
+gnuMakeManual = path.resolve __dirname, '..', 'make.html'
+
+processMakeManual = (content) ->
+  lines = content.split /\r?\n/
+  entries = targets: [], variables: [], functions: [], other_targets: []
+  isSkipped = true
+
+  for line in lines
+    isSkipped = false if line.match /^<a\s+name="Name-Index"><\/a>/
+    continue if isSkipped
+    if m = line.match ///
+      ^<tr><td></td><td\s+valign="top"><a\s+href="[^"]*"><code>([^<]*)
+      </code></a>:</td><td>&nbsp;</td><td\s+valign="top"><a[^>]*>([^<]*)</a></td></tr>
+    ///
+
+      [ match, name, type ] = m
+      name = name.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/, '&')
+      if type.match /function/i or name == 'subst'
+        entries.functions.push name
+      else if type.match /target/i and name.match /^\./
+        entries.targets.push name[1...]
+      else if type.match /target/i
+        entries.other_targets.push name
+      else if (type.match /variable/i)
+        if (m = name.match /^\$\((.*)\)$/)
+          entries.variables.push m[1]
+        else if name.match /^[^$]/
+          entries.variables.push name
+
+  entries
+
+createMakeGrammar = ->
+  process.stderr.write "started\n"
+  getMakeInfo().then (makeInfo) ->
+    grammarFile = path.resolve __dirname, "..", "grammars", "makefile.cson"
+    makeGrammar grammarFactory(makeInfo), grammarFile
+
+getMakeInfo = ->
+  deferred = Q.defer()
+
+  if not fs.existsSync gnuMakeManual
+    http = require 'http'
+    request = http.request 'http://www.gnu.org/software/make/manual/make.html', (res) ->
+
+      res.pipe(fs.createWriteStream gnuMakeManual).on 'end', ->
+        content = fs.readFileSync(gnuMakeManual).toString()
+        deferred.resolve processMakeManual content
+
+    request.on "error", (error) ->
+      deferred.reject(error)
+
+    request.end()
+  else
+    deferred.resolve processMakeManual fs.readFileSync(gnuMakeManual).toString()
+
+  deferred.promise
+
+module.exports = {createMakeGrammar}
+
+if require.main is module
+  createMakeGrammar().then ->
+    console.log "Grammar Created.\n"
+  .catch (error) ->
+    console.log "Error: #{error}\n#{error.stack}\n"


### PR DESCRIPTION
I have rewritten the grammar using atom-syntax-tools to make grammar easier to maintain.  Intention was to add missing language variables in the first place.  The generator downloads GNU Make Manual, parses it and takes (data from index) as input for the rules (for list of functions and language variables).