### PR TITLE
Improve origin and flavor tokenization

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -399,8 +399,11 @@
           }
           {
             'begin': '\\G(origin|flavor)\\s(?=[^\\s)]+\\s*\\))'
+            'beginCaptures':
+              '1':
+                'name': 'support.function.$1.makefile'
             'contentName': 'variable.other.makefile'
-            'end': '\\)'
+            'end': '(?=\\))'
             'name': 'meta.scope.function-call.makefile'
             'patterns': [
               {

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -12,6 +12,9 @@ describe "Makefile grammar", ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe "source.makefile"
 
+  it "selects the Makefile grammar for files that start with a hashbang make -f command", ->
+    expect(atom.grammars.selectGrammar('', '#!/usr/bin/make -f')).toBe grammar
+
   it "parses recipes", ->
     lines = grammar.tokenizeLines 'all: foo.bar\n\ttest\n\nclean: foo\n\trm -fr foo.bar'
 
@@ -46,5 +49,14 @@ describe "Makefile grammar", ->
       expect(lines[1][18]).toEqual value: ')', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'string.interpolated.makefile', 'punctuation.definition.variable.makefile']
       expect(lines[1][19]).toEqual value: ')', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'punctuation.definition.variable.makefile']
 
-  it "selects the Makefile grammar for files that start with a hashbang make -f command", ->
-    expect(atom.grammars.selectGrammar('', '#!/usr/bin/make -f')).toBe grammar
+  it "parses `origin` and `flavor` correctly", ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-shellscript")
+
+    runs ->
+      lines = grammar.tokenizeLines 'default:\n\t$(origin 1)'
+
+      expect(lines[1][1]).toEqual value: '$(', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'punctuation.definition.variable.makefile']
+      expect(lines[1][2]).toEqual value: 'origin', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'support.function.origin.makefile']
+      expect(lines[1][4]).toEqual value: '1', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'meta.scope.function-call.makefile', 'variable.other.makefile']
+      expect(lines[1][5]).toEqual value: ')', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.interpolated.makefile', 'punctuation.definition.variable.makefile']


### PR DESCRIPTION
`origin` and `flavor` now get tokenized as `support.function.{origin|flavor}.makefile` and correctly end when a parentheses is reached.  Not sure why they're kept separate from the other function block but it might be because the GNU manual describes them as special functions.

Fixes #27