### PR TITLE
Add "mkfile" to recognised file extensions

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -7,6 +7,7 @@
   'OCamlMakefile'
   'mf'
   'mk'
+  'mkfile'
   'Makefile.in'
 ]
 'firstLineMatch': '^#!\\s*/.*\\bmake\\s+-f'


### PR DESCRIPTION
Older versions of Unixy systems (or at least Bell Labs' [Plan 9](https://en.wikipedia.org/wiki/Plan_9_from_Bell_Labs)) used the name `mkfile` for their system's makefiles - both as a [filename](https://github.com/codesrxxx/plan9_source/tree/master/sys/src) and an [extension](https://github.com/brho/plan9/blob/89d43d2262ad43eb4b26c2a8d6a27cfeddb33828/sys/lib/sysconfig/auth/boundary/sys.log.mkfile).

[Have submitted a PR](https://github.com/github/linguist/pull/2938) to GitHub's Linguist to cover the name's inclusion, too.