### PR TITLE
Tokenize leading @ in recipes

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -327,8 +327,10 @@
           }
           {
             # https://www.gnu.org/software/make/manual/html_node/Echoing.html
-            'match': '@'
-            'name': 'keyword.other.no-echo.makefile'
+            'match': '(?<=^\\t)\\t*(@)'
+            'captures':
+              '1':
+                'name': 'keyword.other.no-echo.makefile'
           }
           {
             'include': '#variables'

--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -326,6 +326,11 @@
             'name': 'constant.character.escape.continuation.makefile'
           }
           {
+            # https://www.gnu.org/software/make/manual/html_node/Echoing.html
+            'match': '@'
+            'name': 'keyword.other.no-echo.makefile'
+          }
+          {
             'include': '#variables'
           }
           {

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -48,14 +48,14 @@ describe "Makefile grammar", ->
       expect(lines[0][0]).toEqual value: 'all', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
       expect(lines[3][0]).toEqual value: 'clean', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
 
-      # TODO: Enable these specs after language-shellscript@0.25.0 is on stable
-      # lines = grammar.tokenizeLines 'help: # Show this help\n\t@command grep --extended-regexp \'^[a-zA-Z_-]+:.*?# .*$$\' $(MAKEFILE_LIST) | sort | awk \'BEGIN {FS = ":.*?# "}; {printf "\\033[1;39m%-15s\\033[0;39m %s\\n", $$1, $$2}\''
-      # expect(lines[0][0]).toEqual value: 'help', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
-      # expect(lines[0][1]).toEqual value: ':', scopes: ['source.makefile', 'meta.scope.target.makefile', 'punctuation.separator.key-value.makefile']
-      # expect(lines[0][3]).toEqual value: '#', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.prerequisites.makefile', 'comment.line.number-sign.makefile', 'punctuation.definition.comment.makefile']
-      # expect(lines[1][0]).toEqual value: '\t', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile']
-      # expect(lines[1][1]).toEqual value: '@command grep --extended-regexp ', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile']
-      # expect(lines[1][2]).toEqual value: '\'', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
+      lines = grammar.tokenizeLines 'help: # Show this help\n\t@command grep --extended-regexp \'^[a-zA-Z_-]+:.*?# .*$$\' $(MAKEFILE_LIST) | sort | awk \'BEGIN {FS = ":.*?# "}; {printf "\\033[1;39m%-15s\\033[0;39m %s\\n", $$1, $$2}\''
+      expect(lines[0][0]).toEqual value: 'help', scopes: ['source.makefile', 'meta.scope.target.makefile', 'entity.name.function.target.makefile']
+      expect(lines[0][1]).toEqual value: ':', scopes: ['source.makefile', 'meta.scope.target.makefile', 'punctuation.separator.key-value.makefile']
+      expect(lines[0][3]).toEqual value: '#', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.prerequisites.makefile', 'comment.line.number-sign.makefile', 'punctuation.definition.comment.makefile']
+      expect(lines[1][0]).toEqual value: '\t', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile']
+      expect(lines[1][1]).toEqual value: '@', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'keyword.other.no-echo.makefile']
+      expect(lines[1][2]).toEqual value: 'command grep --extended-regexp ', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile']
+      expect(lines[1][3]).toEqual value: '\'', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'string.quoted.single.shell', 'punctuation.definition.string.begin.shell']
 
   testFunctionCall = (functionName) ->
     {tokens} = grammar.tokenizeLine 'foo: echo $(' + functionName + ' /foo/bar.txt)'
@@ -249,3 +249,7 @@ describe "Makefile grammar", ->
     expect(lines[0][0]).toEqual value: 'SOMEVAR', scopes: ['source.makefile', 'variable.other.makefile']
     expect(lines[0][4]).toEqual value: '#', scopes: ['source.makefile', 'comment.line.number-sign.makefile', 'punctuation.definition.comment.makefile']
     expect(lines[1][0]).toEqual value: 'OTHERVAR', scopes: ['source.makefile', 'variable.other.makefile']
+
+  it "tokenizes a leading @ in recipes", ->
+    lines = grammar.tokenizeLines 'target:\n\t@command'
+    expect(lines[1][1]).toEqual value: '@', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'keyword.other.no-echo.makefile']

--- a/spec/make-spec.coffee
+++ b/spec/make-spec.coffee
@@ -251,5 +251,6 @@ describe "Makefile grammar", ->
     expect(lines[1][0]).toEqual value: 'OTHERVAR', scopes: ['source.makefile', 'variable.other.makefile']
 
   it "tokenizes a leading @ in recipes", ->
-    lines = grammar.tokenizeLines 'target:\n\t@command'
+    lines = grammar.tokenizeLines 'target:\n\t@comm@and @nope'
     expect(lines[1][1]).toEqual value: '@', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile', 'keyword.other.no-echo.makefile']
+    expect(lines[1][2]).toEqual value: 'comm@and @nope', scopes: ['source.makefile', 'meta.scope.target.makefile', 'meta.scope.recipe.makefile']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenizes `@` in recipes, which tells make not to echo the line (https://www.gnu.org/software/make/manual/html_node/Echoing.html).

### Alternate Designs

None.

### Benefits

An extra keyword will be highlighted.

### Possible Drawbacks

None.

### Applicable Issues

None.