### PR TITLE
Add "am" to recognised file extensions

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -7,6 +7,7 @@
   'GNUmakefile'
   'OCamlMakefile'
   'Kbuild'
+  'am'
   'mak'
   'make'
   'mf'


### PR DESCRIPTION
### Description of the Change

This PR adds `.am` to the list of supported file extensions. `am` is an abbreviation of [automake](https://www.gnu.org/software/automake/manual/automake.html#amhello_0027s-Makefile_002eam-Setup-Explained).

Resolves #55.

### Alternate Designs

N/A

### Benefits

Self-explanatory.

### Possible Drawbacks / Applicable Issues

N/A
