### PR TITLE
Remove source.shell#string to fix #44 $(error ...) constructs

### DIFF
--- a/grammars/makefile.cson
+++ b/grammars/makefile.cson
@@ -403,9 +403,6 @@
                 'include': '#variables'
               }
               {
-                'include': 'source.shell#string'
-              }
-              {
                 'match': '%|\\*'
                 'name': 'constant.other.placeholder.makefile'
               }


### PR DESCRIPTION
### Description of the Change

Removes `source.shell#variable` from the inner content of `$(error ..)` etc. constricts. This fixes #44. As far as I can tell there are no regressions in my own files.

### Benefits

Basically, `$(error ..)` etc. syntax was being messed up by the presence of quotes or apostrophes, as seen in the screenshot in the issue. We don't need to have any special consideration for quotes or apostrophes because they are included verbatim in the output, no need to escape them.

### Possible Drawbacks

There could be regressions, or cases I haven't considered, but everything seems to work fine.

### Applicable Issues

This fixes #44.
